### PR TITLE
passports.pintan: Benutzer- und Kundenkennung vertauscht

### DIFF
--- a/lib/velocity/passports.pintan.vm
+++ b/lib/velocity/passports.pintan.vm
@@ -95,12 +95,12 @@
     </tr>
     <tr>
       <td>Benutzerkennung</td>
-      <td><input type="text" name="benutzerkennung" value="$!c.currentConfig.customerId" #if($c.currentConfig)readonly#end></td>
+      <td><input type="text" name="benutzerkennung" value="$!c.currentConfig.userId" #if($c.currentConfig)readonly#end></td>
     </tr>
     <tr>
       <td>Kundenkennung</td>
       <td>
-        <input type="text" name="kundenkennung" value="$!c.currentConfig.userId" #if($c.currentConfig)readonly#end>
+        <input type="text" name="kundenkennung" value="$!c.currentConfig.customerId" #if($c.currentConfig)readonly#end>
         <span class="comment">meist identisch mit Benutzerkennung</span>
       </td>
     </tr>


### PR DESCRIPTION
In der Management-Console in der Unterseite
`Home » HBCI-Sicherheitsmedien verwalten » PIN/TAN `
werden die Eingabefelder für Benutzerkennung und Kundenkennung vertauscht verarbeitet.
Das kann reproduziert werden, indem eine Konfiguration angelegt wird und danach wieder geladen.